### PR TITLE
pytest_runtest_call: Avoid running every test twice

### DIFF
--- a/pytest_line_profiler.py
+++ b/pytest_line_profiler.py
@@ -55,12 +55,12 @@ def pytest_runtest_call(item):
     
     if instrumented:
         lp = LineProfiler(*instrumented)
-        lp.runcall(item.runtest)
-        item.config._line_profile = getattr(item.config, "_line_profile", {})
-        item.config._line_profile[item.nodeid] = get_stats(lp)
-    else:
-        item.runtest()
-
+        item_runtest = item.runtest
+        def runtest():
+            lp.runcall(item_runtest)
+            item.config._line_profile = getattr(item.config, "_line_profile", {})
+            item.config._line_profile[item.nodeid] = get_stats(lp)
+        item.runtest = runtest
 
 
 def pytest_terminal_summary(


### PR DESCRIPTION
Instead of calling runtest ourselves, we decorate it, and let pytest's default implementation run our decorated function.

This fixes https://github.com/mgaitan/pytest-line-profiler/issues/1 which apart from impacting performance can lead to subtle issues when running tests.  (In other words, I bumped my head hard. :-)